### PR TITLE
Implement Google auth and update login UI

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -10,12 +10,14 @@ export interface User {
 interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<User>;
+  loginWithGoogle: () => Promise<void>;
   logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   login: async () => {},
+  loginWithGoogle: async () => {},
   logout: async () => {},
 });
 
@@ -49,13 +51,17 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     return current;
   };
 
+  const loginWithGoogle = async () => {
+    await supabase.auth.signInWithOAuth({ provider: "google" });
+  };
+
   const logout = async () => {
     await supabase.auth.signOut();
     setUser(null);
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, loginWithGoogle, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,6 +9,7 @@ const resources = {
         email: "Email",
         password: "Password",
         submit: "Login",
+        google: "Login with Google",
         invalidEmail: "Invalid email address",
         invalidPassword: "Password is required",
         error: "Unable to login"
@@ -22,6 +23,7 @@ const resources = {
         email: "Correo",
         password: "Contrase\u00f1a",
         submit: "Ingresar",
+        google: "Ingresar con Google",
         invalidEmail: "Correo inv\u00e1lido",
         invalidPassword: "La contrase\u00f1a es obligatoria",
         error: "Error al iniciar sesi\u00f3n"

--- a/src/routes/auth/Login.tsx
+++ b/src/routes/auth/Login.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 
 export default function Login() {
   const { t } = useTranslation();
-  const { login } = useAuth();
+  const { login, loginWithGoogle } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -59,6 +59,9 @@ export default function Login() {
         </div>
         <Button type="submit" className="w-full">
           {t("login.submit")}
+        </Button>
+        <Button type="button" className="w-full" onClick={loginWithGoogle}>
+          {t("login.google")}
         </Button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add Google login flow in auth hook
- support Google login via button on Login page
- expose Google login translation messages

## Testing
- `npm test`
- `npm run dev` *(server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68814601265083248392542e4bde12ee